### PR TITLE
Add feature 'core_collections'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,7 @@ Rust interface for the FreeRTOS embedded operating system.
 name = "freertos_rs"
 
 [dependencies]
+
+[features]
+default = []
+core_collections = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@
 #![cfg_attr(feature = "core_collections", feature(collections))]
 #![feature(fnbox)]
 
-#![cfg_attr(not(feature = "core_collections"), macro_use)]
+#[cfg_attr(feature = "default", macro_use)]
 extern crate alloc;
 
 #[cfg(feature = "core_collections")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,11 +54,14 @@
 #![no_std]
 
 #![feature(alloc)]
+#![cfg_attr(feature = "core_collections", feature(collections))]
 #![feature(fnbox)]
 
-#[macro_use]
+#![cfg_attr(not(feature = "core_collections"), macro_use)]
 extern crate alloc;
 
+#[cfg(feature = "core_collections")]
+#[macro_use] extern crate collections;
 
 mod prelude;
 mod shim;

--- a/src/prelude/no_std.rs
+++ b/src/prelude/no_std.rs
@@ -15,5 +15,13 @@ pub use core::ptr;
 pub use alloc::rc::Rc;
 pub use alloc::boxed::{Box, FnBox};
 pub use alloc::arc::{Arc, Weak};
+
+#[cfg(not(feature = "core_collections"))]
 pub use alloc::vec::Vec;
+#[cfg(not(feature = "core_collections"))]
 pub use alloc::string::*;
+
+#[cfg(feature = "core_collections")]
+pub use collections::vec::Vec;
+#[cfg(feature = "core_collections")]
+pub use collections::string::*;


### PR DESCRIPTION
Hi,

Unfortunately currently I tied to certain version of rustc. In this version `collections` crate is not deprecated yet. I added feature that allows to use such old rustc versions.