### PR TITLE
Added uninitialized for Queue

### DIFF
--- a/src/queue.rs
+++ b/src/queue.rs
@@ -31,6 +31,14 @@ impl<T: Sized + Copy> Queue<T> {
             item_type: PhantomData,
         })
     }
+    
+    
+    pub unsafe fn uninitialized() -> Self {
+        Self {
+            queue: core::ptr::null(),
+            item_type: PhantomData,
+        }
+    }
 
     /// Send an item to the end of the queue. Wait for the queue to have empty space for it.
     pub fn send<D: DurationTicks>(&self, item: T, max_wait: D) -> Result<(), FreeRtosError> {


### PR DESCRIPTION
Certain functions in ESP-IDR (for example [uart_driver_install](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/uart.html#_CPPv419uart_driver_install11uart_port_tiiiP13QueueHandle_ti) ) asks for an uninitialized Queue pointer. This creates an additional method in `Queue` to creates an uninitialized queue so that they could be initialized by something else.
